### PR TITLE
Update OpenAI-TTS endpoints to use fetch custom URL voices and models

### DIFF
--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -679,8 +679,6 @@ def transcription(
 
 def get_available_models(request: Request) -> list[dict]:
     available_models = []
-    """if request.app.state.config.TTS_ENGINE == "openai":
-        available_models = [{"id": "tts-1"}, {"id": "tts-1-hd"}]"""
     if request.app.state.config.TTS_ENGINE == "openai":
         # Use custom endpoint if not using the official OpenAI API URL
         if not request.app.state.config.TTS_OPENAI_API_BASE_URL.startswith("https://api.openai.com"):
@@ -723,15 +721,6 @@ async def get_models(request: Request, user=Depends(get_verified_user)):
 def get_available_voices(request) -> dict:
     """Returns {voice_id: voice_name} dict"""
     available_voices = {}
-    """if request.app.state.config.TTS_ENGINE == "openai":
-        available_voices = {
-            "alloy": "alloy",
-            "echo": "echo",
-            "fable": "fable",
-            "onyx": "onyx",
-            "nova": "nova",
-            "shimmer": "shimmer",
-        }"""
     if request.app.state.config.TTS_ENGINE == "openai":
         # Use custom endpoint if not using the official OpenAI API URL
         if not request.app.state.config.TTS_OPENAI_API_BASE_URL.startswith("https://api.openai.com"):

--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -679,8 +679,21 @@ def transcription(
 
 def get_available_models(request: Request) -> list[dict]:
     available_models = []
+    """if request.app.state.config.TTS_ENGINE == "openai":
+        available_models = [{"id": "tts-1"}, {"id": "tts-1-hd"}]"""
     if request.app.state.config.TTS_ENGINE == "openai":
-        available_models = [{"id": "tts-1"}, {"id": "tts-1-hd"}]
+        # Use custom endpoint if not using the official OpenAI API URL
+        if not request.app.state.config.TTS_OPENAI_API_BASE_URL.startswith("https://api.openai.com"):
+            try:
+                response = requests.get(f"{request.app.state.config.TTS_OPENAI_API_BASE_URL}/audio/models")
+                response.raise_for_status()
+                data = response.json()
+                available_models = data.get("models", [])
+            except Exception as e:
+                log.error(f"Error fetching models from custom endpoint: {str(e)}")
+                available_models = []
+        else:
+            available_models = [{"id": "tts-1"}, {"id": "tts-1-hd"}]
     elif request.app.state.config.TTS_ENGINE == "elevenlabs":
         try:
             response = requests.get(
@@ -710,7 +723,7 @@ async def get_models(request: Request, user=Depends(get_verified_user)):
 def get_available_voices(request) -> dict:
     """Returns {voice_id: voice_name} dict"""
     available_voices = {}
-    if request.app.state.config.TTS_ENGINE == "openai":
+    """if request.app.state.config.TTS_ENGINE == "openai":
         available_voices = {
             "alloy": "alloy",
             "echo": "echo",
@@ -718,7 +731,28 @@ def get_available_voices(request) -> dict:
             "onyx": "onyx",
             "nova": "nova",
             "shimmer": "shimmer",
-        }
+        }"""
+    if request.app.state.config.TTS_ENGINE == "openai":
+        # Use custom endpoint if not using the official OpenAI API URL
+        if not request.app.state.config.TTS_OPENAI_API_BASE_URL.startswith("https://api.openai.com"):
+            try:
+                response = requests.get(f"{request.app.state.config.TTS_OPENAI_API_BASE_URL}/audio/voices")
+                response.raise_for_status()
+                data = response.json()
+                voices_list = data.get("voices", [])
+                available_voices = {voice["id"]: voice["name"] for voice in voices_list}
+            except Exception as e:
+                log.error(f"Error fetching voices from custom endpoint: {str(e)}")
+                available_voices = {}
+        else:
+            available_voices = {
+                "alloy": "alloy",
+                "echo": "echo",
+                "fable": "fable",
+                "onyx": "onyx",
+                "nova": "nova",
+                "shimmer": "shimmer",
+            }
     elif request.app.state.config.TTS_ENGINE == "elevenlabs":
         try:
             available_voices = get_elevenlabs_voices(


### PR DESCRIPTION
This PR updates the OpenAI-TTS endpoints so that if the supplied TTS_OPENAI_API_BASE_URL does not start with 'https://api.openai.com', if it does not match we fetch voices and models from the custom endpoint TTS_OPENAI_API_BASE_URL ({TTS_OPENAI_API_BASE_URL}/audio/voices and {TTS_OPENAI_API_BASE_URL}/audio/models) instead of using the previously hard-coded official OpenAI-TTS-specific defaults.